### PR TITLE
Fix the logic scraping naver stock

### DIFF
--- a/src/main/kotlin/com/example/mediaproject/api/service/StockCompanyServiceImpl.kt
+++ b/src/main/kotlin/com/example/mediaproject/api/service/StockCompanyServiceImpl.kt
@@ -13,6 +13,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import retrofit2.Response
+import java.lang.Integer.min
 import javax.transaction.Transactional
 import kotlin.streams.toList
 
@@ -29,7 +30,12 @@ class StockCompanyServiceImpl(
     override fun getCompanyStockData(q: String?): List<CompanyResponse> {
         val companyList: List<Company> = companyRepositorySupport.getAllCompanyWithQ(q)
 
-        val naverStockItemList: List<NaverStockItem> = requestToNaverStock(companyList)
+        val naverStockItemList: MutableList<NaverStockItem> = mutableListOf()
+        var idx = 0
+        while (idx <= companyList.size) {
+            naverStockItemList.addAll(requestToNaverStock(companyList.subList(idx, min(idx+15, companyList.size))))
+            idx += 15
+        }
 
         return naverStockItemList.map { companyResponseOf(it) }
     }


### PR DESCRIPTION
네이버 주식 정보 15개 제한 대응 코드 추가
- 15개씩 여러 번에 걸쳐 요청하도록 수정